### PR TITLE
Make letters overlap to eliminate double border

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -310,11 +310,12 @@ a {
   grid-area: board;
   display: grid;
   touch-action: none;
-  justify-content: center;
+  justify-content: start;
+  align-content: start;
   grid-template-columns: repeat(12, var(--box-size));
   grid-template-rows: repeat(12, var(--box-size));
-  width: fit-content;
-  height: fit-content;
+  width: calc(12 * var(--box-size) + 1px);
+  height: calc(12 * var(--box-size) + 1px);
   justify-self: center;
   color: var(--light-color);
   border: 1px solid var(--light-color);

--- a/src/App.css
+++ b/src/App.css
@@ -322,6 +322,10 @@ a {
 }
 
 .letter {
+  box-sizing: border-box;
+  width: calc(var(--box-size) + 1px);
+  height: calc(var(--box-size) + 1px);
+
   display: flex;
   pointer-events: auto;
   touch-action: none;
@@ -418,6 +422,22 @@ a {
 
 .shadow-square {
   background-color: var(--shadow-color);
+  box-sizing: border-box;
+  position: relative;
+  left: 0;
+  top: 0;
+  width: calc(var(--box-size) + 1px);
+  height: calc(var(--box-size) + 1px);
+}
+
+.shadow-square.shadow-to-left {
+  left: 1px;
+  width: var(--box-size);
+}
+
+.shadow-square.shadow-to-top {
+  top: 1px;
+  height: var(--box-size);
 }
 
 .rules {

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -106,8 +106,10 @@ export function dragDestinationOnBoard(gameState, pointer) {
     const maxTop = gameState.gridSize - groupHeight;
     const maxLeft = gameState.gridSize - groupWidth;
 
-    const squareWidth = boardRect.width / gameState.gridSize;
-    const squareHeight = boardRect.height / gameState.gridSize;
+    // Subtract 1 before dividing because the board is 12 squares wide, but has 13 1px borders.
+    // (It's admittedly silly to care about this, since the impact is only 1/12 of a pixel!)
+    const squareWidth = (boardRect.width - 1) / gameState.gridSize;
+    const squareHeight = (boardRect.height - 1) / gameState.gridSize;
     const pointerOffset = gameState.dragState.pointerOffset;
     const unclampedLeft = Math.round(
       (pointer.x - pointerOffset.x - boardRect.left) / squareWidth

--- a/src/components/DragShadow.js
+++ b/src/components/DragShadow.js
@@ -1,9 +1,16 @@
 import React from "react";
 
-function DragShadowSquare({ rowIndex, colIndex }) {
+function DragShadowSquare({ rowIndex, colIndex, hasShadowToTop, hasShadowToLeft }) {
+  let className = "shadow-square";
+  if (hasShadowToTop) {
+    className += " shadow-to-top";
+  }
+  if (hasShadowToLeft) {
+    className += " shadow-to-left";
+  }
   return (
     <div
-      className="shadow-square"
+      className={className}
       style={{
         gridRow: rowIndex + 1, // CSS grid coordinates are 1-based
         gridColumn: colIndex + 1,
@@ -22,6 +29,8 @@ export default function DragShadow({ grid, top, left }) {
             key={`${rowIndex}-${colIndex}`}
             rowIndex={rowIndex}
             colIndex={colIndex}
+            hasShadowToTop={rowIndex > 0 && grid[rowIndex - 1][colIndex] > 0}
+            hasShadowToLeft={colIndex > 0 && grid[rowIndex][colIndex - 1] > 0}
           />
         );
       }


### PR DESCRIPTION
Each piece has a 1px border. So currently, when you place two pieces adjacent, you get a 2px border between them.

<img width="134" alt="Two pieces set corner-to-corner; the borders don't line up." src="https://github.com/jorendorff/crossjig/assets/283361/2d55beab-0fe1-4400-8fc5-0f2d5c62b1c3"> <img width="122" alt="Adjacent pieces with 2px of border between them." src="https://github.com/jorendorff/crossjig/assets/283361/9ca38d7f-100e-482d-ac0e-e0f8f13db6b1">

Also, when a piece has an concave corner (like the two inner corners on a T-shaped piece, for example), there is a 1px square missing where the border isn't drawn through the interior corner as you'd expect.

<img width="105" alt="L-shaped piece with a pixel missing from the border." src="https://github.com/jorendorff/crossjig/assets/283361/433aa810-706f-4aef-9064-be3cd8007e3b">

This PR makes the letters overlap slightly so that the border between adjacent pieces is only 1px and interior corners look nice.

After: <img width="273" alt="Several adjacent pieces with only 1px of border between them." src="https://github.com/jorendorff/crossjig/assets/283361/d01e5038-f512-4161-ba30-613410cc3814"> <img width="108" alt="Pieces set corner-to-corner; the borders now line up." src="https://github.com/jorendorff/crossjig/assets/283361/c38d6985-36c5-4202-a480-dd3d1d42c9f2">

